### PR TITLE
feat(tags): enable tags to be set in the stasharr settings

### DIFF
--- a/src/builder/PerformerPayloadBuilder.ts
+++ b/src/builder/PerformerPayloadBuilder.ts
@@ -13,7 +13,7 @@ export class PerformerPayloadBuilder {
     };
   }
 
-  setTags(tags: string[]) {
+  setTags(tags: number[]) {
     this.payload.tags = tags;
     return this;
   }

--- a/src/builder/ScenePayloadBuilder.ts
+++ b/src/builder/ScenePayloadBuilder.ts
@@ -11,7 +11,13 @@ export class ScenePayloadBuilder {
       monitored: true,
       addOptions: { searchForMovie: true },
       qualityProfileId: 0,
+      tags: [],
     };
+  }
+
+  setTags(tags: number[]) {
+    this.payload.tags = tags;
+    return this;
   }
 
   setTitle(title: string) {

--- a/src/builder/StudioPayloadBuilder.ts
+++ b/src/builder/StudioPayloadBuilder.ts
@@ -13,7 +13,7 @@ export class StudioPayloadBuilder {
     };
   }
 
-  setTags(tags: string[]) {
+  setTags(tags: number[]) {
     this.payload.tags = tags;
     return this;
   }

--- a/src/components/scene/header/Details.tsx
+++ b/src/components/scene/header/Details.tsx
@@ -21,7 +21,7 @@ const Details = (props: { config: Config; stashId: string }) => {
   const [qualityProfiles] = createResource(
     props,
     async (p: { config: Config }) => {
-      return WhisparrService.getQualityProfiles(p.config);
+      return WhisparrService.qualityProfiles(p.config);
     },
   );
 

--- a/src/components/settings/DomainInput.tsx
+++ b/src/components/settings/DomainInput.tsx
@@ -1,5 +1,5 @@
-import { Stasharr } from '../enums/Stasharr';
-import { useSettings } from '../contexts/useSettings';
+import { Stasharr } from '../../enums/Stasharr';
+import { useSettings } from '../../contexts/useSettings';
 
 const DomainInput = () => {
   const { store, setStore } = useSettings();

--- a/src/components/settings/NavbarLink.tsx
+++ b/src/components/settings/NavbarLink.tsx
@@ -1,4 +1,4 @@
-import { Stasharr } from '../enums/Stasharr';
+import { Stasharr } from '../../enums/Stasharr';
 
 const NavbarLink = () => (
   <a

--- a/src/components/settings/ProtocolSwitch.tsx
+++ b/src/components/settings/ProtocolSwitch.tsx
@@ -1,5 +1,5 @@
-import { Stasharr } from '../enums/Stasharr';
-import { useSettings } from '../contexts/useSettings';
+import { Stasharr } from '../../enums/Stasharr';
+import { useSettings } from '../../contexts/useSettings';
 
 const ProtocolSwitch = () => {
   const { store, setStore } = useSettings();

--- a/src/components/settings/QualityProfile.tsx
+++ b/src/components/settings/QualityProfile.tsx
@@ -1,8 +1,8 @@
 import { For } from 'solid-js';
-import { useSettings } from '../contexts/useSettings';
+import { useSettings } from '../../contexts/useSettings';
 import { Form } from 'solid-bootstrap';
-import { Whisparr } from '../types/whisparr';
-import { Stasharr } from '../enums/Stasharr';
+import { Whisparr } from '../../types/whisparr';
+import { Stasharr } from '../../enums/Stasharr';
 
 const QualityProfileSelect = (props: {
   qualityProfiles: Whisparr.QualityProfile[] | undefined;

--- a/src/components/settings/RootFolderPath.tsx
+++ b/src/components/settings/RootFolderPath.tsx
@@ -1,8 +1,8 @@
 import { For } from 'solid-js';
-import { useSettings } from '../contexts/useSettings';
+import { useSettings } from '../../contexts/useSettings';
 import { Form } from 'solid-bootstrap';
-import { Whisparr } from '../types/whisparr';
-import { Stasharr } from '../enums/Stasharr';
+import { Whisparr } from '../../types/whisparr';
+import { Stasharr } from '../../enums/Stasharr';
 
 const RootFolderPathSelect = (props: {
   rootFolderPaths: Whisparr.RootFolder[] | undefined;

--- a/src/components/settings/SearchOnAdd.tsx
+++ b/src/components/settings/SearchOnAdd.tsx
@@ -1,7 +1,7 @@
 import { For } from 'solid-js';
-import { useSettings } from '../contexts/useSettings';
+import { useSettings } from '../../contexts/useSettings';
 import { Form } from 'solid-bootstrap';
-import { Stasharr } from '../enums/Stasharr';
+import { Stasharr } from '../../enums/Stasharr';
 
 const SearchOnAddSelect = () => {
   const { store, setStore } = useSettings();

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -8,16 +8,17 @@ import {
 import { Modal, Button, Alert } from 'solid-bootstrap';
 import ProtocolSwitch from './ProtocolSwitch';
 import DomainInput from './DomainInput';
-import WhisparrApiKeyInput from './ApiKeyInput';
+import WhisparrApiKeyInput from '../ApiKeyInput';
 import { createStore } from 'solid-js/store';
-import { Config } from '../models/Config';
-import WhisparrService from '../service/WhisparrService';
-import { SettingsContext } from '../contexts/useSettings';
+import { Config } from '../../models/Config';
+import WhisparrService from '../../service/WhisparrService';
+import { SettingsContext } from '../../contexts/useSettings';
 import QualityProfileSelect from './QualityProfile';
 import { parseInt } from 'lodash';
 import RootFolderPathSelect from './RootFolderPath';
 import SearchOnAddSelect from './SearchOnAdd';
-import { Stasharr } from '../enums/Stasharr';
+import { Stasharr } from '../../enums/Stasharr';
+import Tags from './Tags';
 
 function SettingsModal(props: { config: Config }) {
   const [show, setShow] = createSignal(false);
@@ -93,6 +94,7 @@ function SettingsModal(props: { config: Config }) {
             <QualityProfileSelect qualityProfiles={qualityProfiles()} />
             <RootFolderPathSelect rootFolderPaths={rootFolderPaths()} />
             <SearchOnAddSelect />
+            <Tags />
           </Show>
         </Modal.Body>
         <Modal.Footer>

--- a/src/components/settings/StashInstance.tsx
+++ b/src/components/settings/StashInstance.tsx
@@ -1,5 +1,5 @@
-import { useSettings } from '../contexts/useSettings';
-import { Stasharr } from '../enums/Stasharr';
+import { useSettings } from '../../contexts/useSettings';
+import { Stasharr } from '../../enums/Stasharr';
 
 const StashInstance = () => {
   const { store, setStore } = useSettings();

--- a/src/components/settings/Tags.tsx
+++ b/src/components/settings/Tags.tsx
@@ -1,0 +1,60 @@
+import { Form } from 'solid-bootstrap';
+import { useSettings } from '../../contexts/useSettings';
+import { Stasharr } from '../../enums/Stasharr';
+import { createMemo, createResource, For } from 'solid-js';
+import { Config } from '../../models/Config';
+import WhisparrService from '../../service/WhisparrService';
+import { parseInt } from 'lodash';
+
+const Tags = () => {
+  const { store, setStore } = useSettings();
+
+  const reactiveStore = createMemo(
+    () => new Config(store.protocol, store.domain, store.whisparrApiKey),
+  );
+
+  const [tags] = createResource(reactiveStore, async (s) => {
+    if (!s.domain || !s.whisparrApiKey) return [];
+    return WhisparrService.tags(s) || [];
+  });
+
+  const handleTagsChange = (
+    // eslint-disable-next-line no-undef
+    selectedOptions: HTMLCollectionOf<HTMLOptionElement>,
+  ) => {
+    if (selectedOptions.length === 0) setStore('tags', []);
+    let tags: number[] = [];
+    for (let i = 0; i < selectedOptions.length; i++) {
+      const option = selectedOptions.item(i);
+      if (option) tags.push(parseInt(option.value, 10));
+    }
+    setStore('tags', tags);
+  };
+  return (
+    <div class="input-group mb-3">
+      <label class="input-group-text">Tags</label>
+      <Form.Select
+        aria-label="Tags select"
+        multiple={true}
+        onChange={(e) => handleTagsChange(e.target.selectedOptions)}
+        // value={store.tags.map((tag) => tag + '')}
+        id={Stasharr.ID.Modal.Tags}
+        data-bs-toggle="tooltip"
+        data-bs-title="Enter tags to be associated with the scenes, studios, and performers added via Stasharr."
+      >
+        <For each={tags()}>
+          {(tag) => (
+            <option
+              value={tag.id}
+              selected={store.tags.filter((t) => t === tag.id).length > 0}
+            >
+              {tag.label}
+            </option>
+          )}
+        </For>
+      </Form.Select>
+    </div>
+  );
+};
+
+export default Tags;

--- a/src/controller/NavbarController.ts
+++ b/src/controller/NavbarController.ts
@@ -1,5 +1,5 @@
 import { render } from 'solid-js/web';
-import SettingsModal from '../components/SettingsModal';
+import SettingsModal from '../components/settings/SettingsModal';
 import { Config } from '../models/Config';
 import { BaseController } from './BaseController';
 import { StashDB } from '../enums/StashDB';

--- a/src/enums/Stasharr.ts
+++ b/src/enums/Stasharr.ts
@@ -20,6 +20,7 @@ const qualityProfile = `${stasharrPrefix}-qualityProfile`;
 const rootFolderPath = `${stasharrPrefix}-rootFolderPath`;
 const searchOnAdd = `${stasharrPrefix}-searchOnAdd`;
 const stashDomain = `${stasharrPrefix}-stashDomain`;
+const tags = `${stasharrPrefix}-tags`;
 const headerDetails = `${stasharrPrefix}-headerDetails`;
 const whisparrCardButton = `whisparr-card-button`;
 
@@ -45,6 +46,7 @@ export const Stasharr = {
       RootFolderPath: rootFolderPath,
       SearchOnAdd: searchOnAdd,
       StashDomain: stashDomain,
+      Tags: tags,
     },
   },
   DOMSelector: {

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -8,6 +8,7 @@ export class Config {
   rootFolderPath: string = '';
   searchForNewMovie: boolean = true;
   stashDomain: string = 'http://localhost:9999';
+  tags: number[] = [];
 
   constructor(protocol?: boolean, domain?: string, whisparrApiKey?: string) {
     if (protocol) this.protocol = protocol;

--- a/src/service/PerformerService.ts
+++ b/src/service/PerformerService.ts
@@ -74,6 +74,7 @@ export default class PerformerService extends ServiceBase {
       .setQualityProfileId(config.qualityProfile)
       .setRootFolderPath(config.rootFolderPath)
       .setSearchOnAdd(config.searchForNewMovie)
+      .setTags(config.tags)
       .build();
     const response = await ServiceBase.request(
       config,

--- a/src/service/SceneService.ts
+++ b/src/service/SceneService.ts
@@ -163,6 +163,7 @@ export default class SceneService extends ServiceBase {
       .setQualityProfileId(config.qualityProfile)
       .setRootFolderPath(config.rootFolderPath)
       .setSearchForMovie(config.searchForNewMovie)
+      .setTags(config.tags)
       .build();
     let response;
     try {

--- a/src/service/StudioService.ts
+++ b/src/service/StudioService.ts
@@ -69,6 +69,7 @@ export default class StudioService extends ServiceBase {
       .setQualityProfileId(config.qualityProfile)
       .setRootFolderPath(config.rootFolderPath)
       .setSearchOnAdd(config.searchForNewMovie)
+      .setTags(config.tags)
       .build();
     const response = await ServiceBase.request(
       config,

--- a/src/service/WhisparrService.ts
+++ b/src/service/WhisparrService.ts
@@ -61,26 +61,6 @@ export default class WhisparrService extends ServiceBase {
     }
   }
 
-  static async getQualityProfiles(
-    config: Config,
-  ): Promise<Whisparr.QualityProfile[]> {
-    const endpoint = 'qualityProfile';
-    const response = await ServiceBase.request(
-      config,
-      endpoint,
-      'GET',
-      undefined,
-      {
-        'Content-Type': 'application/json',
-      },
-    )
-      .then((response) => response.response)
-      .then((json) => {
-        return json as Whisparr.QualityProfile[];
-      });
-    return response;
-  }
-
   static async qualityProfiles(
     config: Config,
   ): Promise<null | Whisparr.QualityProfile[]> {
@@ -95,60 +75,6 @@ export default class WhisparrService extends ServiceBase {
     return response.response as Whisparr.QualityProfile[];
   }
 
-  static async getQualityProfilesForSelectMenu(
-    config: Config,
-  ): Promise<{ id: number; name: string }[]> {
-    let options: { id: number; name: string }[] = [];
-    await WhisparrService.getQualityProfiles(config).then(
-      (response: Whisparr.QualityProfile[]) => {
-        response.forEach((qualityProfile) => {
-          options.push({
-            id: qualityProfile.id,
-            name: qualityProfile.name,
-          });
-        });
-      },
-    );
-    return options;
-  }
-
-  static async getRootFolderPathsForSelectMenu(
-    config: Config,
-  ): Promise<{ id: number; name: string }[]> {
-    let options: { id: number; name: string }[] = [];
-
-    await WhisparrService.getRootFolders(config).then(
-      (response: Whisparr.RootFolder[]) => {
-        response.forEach((rootFolder) => {
-          options.push({
-            id: rootFolder.id,
-            name: rootFolder.path,
-          });
-        });
-      },
-    );
-
-    return options;
-  }
-
-  static async getRootFolders(config: Config): Promise<Whisparr.RootFolder[]> {
-    const endpoint = 'rootFolder';
-    const response = await ServiceBase.request(
-      config,
-      endpoint,
-      'GET',
-      undefined,
-      {
-        'Content-Type': 'application/json',
-      },
-    )
-      .then((response) => response.response)
-      .then((json) => {
-        return json as Whisparr.RootFolder[];
-      });
-    return response;
-  }
-
   static async rootFolderPaths(
     config: Config,
   ): Promise<null | Whisparr.RootFolder[]> {
@@ -161,5 +87,17 @@ export default class WhisparrService extends ServiceBase {
       return null;
     }
     return response.response as Whisparr.RootFolder[];
+  }
+
+  static async tags(config: Config): Promise<Whisparr.Tag[] | null> {
+    const endpoint = 'tag';
+    let response;
+    try {
+      response = await ServiceBase.request(config, endpoint, 'GET', undefined);
+    } catch (e) {
+      console.log('Error getting Tags: ', e);
+      return null;
+    }
+    return response.response as Whisparr.Tag[];
   }
 }

--- a/src/types/whisparr.d.ts
+++ b/src/types/whisparr.d.ts
@@ -36,7 +36,7 @@ export namespace Whisparr {
     titleSlug: string;
     folder: string;
     genres: string[];
-    tags: string[];
+    tags: Tag[];
     added: string;
     ratings: Record<string, unknown>;
     credits: unknown[];
@@ -70,7 +70,7 @@ export namespace Whisparr {
     titleSlug: string;
     rootFolderPath: string;
     genres: string[];
-    tags: string[];
+    tags: Tag[];
     added: string;
     foreignId: string;
     movie: Movie;
@@ -116,10 +116,11 @@ export namespace Whisparr {
       searchForMovie: boolean;
     };
     qualityProfileId: number;
+    tags: number[];
   };
 
   type PerformerPayload = {
-    tags: string[];
+    tags: number[];
     foreignId: string;
     searchOnAdd: boolean;
     qualityProfileId: number;
@@ -133,7 +134,7 @@ export namespace Whisparr {
     qualityProfileId: number;
     rootFolderPath: string;
     monitored: boolean;
-    tags: string[];
+    tags: number[];
   };
 
   type ExclusionPayload = {
@@ -214,7 +215,7 @@ export namespace Whisparr {
     rootFolderPath: string;
     qualityProfile: string;
     searchOnAdd: boolean;
-    tags: string[];
+    tags: Tag[];
     added: string;
     id: number;
   };
@@ -270,5 +271,10 @@ export namespace Whisparr {
     packageVersion: string;
     packageAuthor: string;
     packageUpdateMechanism: string;
+  };
+
+  type Tag = {
+    label: string;
+    id: number;
   };
 }


### PR DESCRIPTION
Allows users to set which tags will be associated with studios, scenes, and performers when they are added to Whisparr using Stasharr.

fix #49