### PR TITLE
feat(actions,ui): improve bulk actions UX with scene titles and modal feedback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "chatgpt.openOnStartup": true
+}

--- a/src/components/BulkActionDropdown.tsx
+++ b/src/components/BulkActionDropdown.tsx
@@ -160,12 +160,12 @@ const BulkActionDropdown = () => {
     });
 
     if (progressItems.length === 0) {
-      // Use progress modal instead of toast for consistent feedback
+      // Use progress modal with empty-state info
       const progressTracker = FeedbackService.startBulkOperation(
         `Add All Scenes - Page ${pageNumber + 1}`,
-        [{ id: 'none', name: 'No scenes available to add on this page.' }],
+        [],
       );
-      progressTracker.updateItem('none', 'success');
+      progressTracker.setInfo('No scenes available to add on this page.');
       progressTracker.complete();
       return;
     }
@@ -284,12 +284,13 @@ const BulkActionDropdown = () => {
     });
 
     if (stashIds.length === 0) {
-      // Use progress modal instead of toast for consistent feedback
+      // Use progress modal with empty-state info
       const progressTracker = FeedbackService.startBulkOperation(
         `Search All Scenes - Page ${pageNumber + 1}`,
-        [{ id: 'none', name: 'No scenes available to search on this page.' }],
+        [],
       );
-      progressTracker.updateItem('none', 'success');
+      // @ts-ignore: runtime method exists on tracker
+      progressTracker.setInfo('No scenes available to search on this page.');
       progressTracker.complete();
       return;
     }

--- a/src/components/BulkActionDropdown.tsx
+++ b/src/components/BulkActionDropdown.tsx
@@ -289,7 +289,6 @@ const BulkActionDropdown = () => {
         `Search All Scenes - Page ${pageNumber + 1}`,
         [],
       );
-      // @ts-ignore: runtime method exists on tracker
       progressTracker.setInfo('No scenes available to search on this page.');
       progressTracker.complete();
       return;

--- a/src/components/BulkActionDropdown.tsx
+++ b/src/components/BulkActionDropdown.tsx
@@ -1,0 +1,226 @@
+import { createSignal } from 'solid-js';
+import { Dropdown } from 'solid-bootstrap';
+import { FontAwesomeIcon } from 'solid-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import {
+  faChevronDown,
+  faSearch,
+  faDownload,
+  faSyncAlt,
+} from '@fortawesome/free-solid-svg-icons';
+import { useSettings } from '../contexts/useSettings';
+import SceneService from '../service/SceneService';
+import ToastService from '../service/ToastService';
+import { extractStashIdFromSceneCard, rehydrateSceneCards } from '../util/util';
+import { StashIdToSceneCardAndStatusMap } from '../types/stasharr';
+import { SceneStatus, SceneStatusType } from '../enums/SceneStatus';
+import { Stasharr } from '../enums/Stasharr';
+import { StashDB } from '../enums/StashDB';
+import { parseInt } from 'lodash';
+
+library.add(faChevronDown, faSearch, faDownload, faSyncAlt);
+
+export enum BulkActionType {
+  ADD_ALL = 'add_all',
+  ADD_ALL_MISSING = 'add_all_missing',
+  SEARCH_ALL = 'search_all',
+}
+
+const BulkActionDropdown = () => {
+  const { store } = useSettings();
+  const [isOpen, setIsOpen] = createSignal(false);
+
+  const handleAction = async (actionType: BulkActionType) => {
+    setIsOpen(false);
+
+    switch (actionType) {
+      case BulkActionType.ADD_ALL_MISSING:
+        await handleAddAllMissing();
+        break;
+      case BulkActionType.ADD_ALL:
+        await handleAddAll();
+        break;
+      case BulkActionType.SEARCH_ALL:
+        await handleSearchAll();
+        break;
+    }
+  };
+
+  const handleAddAllMissing = async () => {
+    const confirmed = window.confirm(
+      'This will search StashDB and Whisparr to find ALL missing scenes from the current context (studio/performer/page). ' +
+        'This operation may take several minutes and will query both APIs extensively. Continue?',
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const results = await SceneService.addAllMissingScenes(store);
+      ToastService.showToast(
+        `Add All Missing completed: ${results.totalAdded} scenes added, ${results.failed.length} failed`,
+        results.failed.length === 0,
+      );
+    } catch (error) {
+      console.error('Add All Missing failed:', error);
+      ToastService.showToast('Add All Missing operation failed', false);
+    }
+  };
+
+  const handleAddAll = async () => {
+    const pageNumber: number = parseInt(
+      document
+        .querySelector<HTMLElement>(StashDB.DOMSelector.DataPage)
+        ?.getAttribute(StashDB.DataAttribute.DataPage) || '{Page not found}',
+    );
+
+    const stashIdtoSceneCardAndStatusMap: StashIdToSceneCardAndStatusMap =
+      new Map();
+    const sceneCards = document.querySelectorAll<HTMLElement>(
+      Stasharr.DOMSelector.SceneCardByButtonStatus(SceneStatus.NOT_IN_WHISPARR),
+    );
+
+    sceneCards.forEach((node) => {
+      const stashId = extractStashIdFromSceneCard(node);
+      if (stashId) {
+        const sceneStatusRaw = node
+          .querySelector(Stasharr.DOMSelector.CardButton)
+          ?.getAttribute(Stasharr.DataAttribute.SceneStatus);
+        const sceneStatusNumber = parseInt(sceneStatusRaw || '-1', 10);
+
+        if (sceneStatusNumber > -1) {
+          stashIdtoSceneCardAndStatusMap.set(stashId, {
+            status: sceneStatusNumber as SceneStatusType,
+            sceneCard: node,
+          });
+        }
+      }
+    });
+
+    try {
+      const sceneMap = await SceneService.lookupAndAddAll(
+        store,
+        stashIdtoSceneCardAndStatusMap,
+      );
+      ToastService.showToast(
+        `Added ${sceneMap.size} new scenes to Whisparr from page ${pageNumber + 1}.`,
+        true,
+      );
+      rehydrateSceneCards(store, sceneMap);
+    } catch (error) {
+      console.error('Add All failed:', error);
+      ToastService.showToast('Add All operation failed', false);
+    }
+  };
+
+  const handleSearchAll = async () => {
+    const pageNumber: number = parseInt(
+      document
+        .querySelector<HTMLElement>(StashDB.DOMSelector.DataPage)
+        ?.getAttribute(StashDB.DataAttribute.DataPage) || '{Page not found}',
+    );
+
+    const stashIds: string[] = [];
+    const sceneCards = document.querySelectorAll<HTMLElement>(
+      Stasharr.DOMSelector.SceneCardByButtonStatus(
+        SceneStatus.EXISTS_AND_NO_FILE,
+      ),
+    );
+
+    sceneCards.forEach((node) => {
+      const stashId = extractStashIdFromSceneCard(node);
+      if (stashId) {
+        stashIds.push(stashId);
+      }
+    });
+
+    try {
+      await SceneService.triggerWhisparrSearchAll(store, stashIds);
+      ToastService.showToast(
+        `Triggered search for ${stashIds.length} existing scenes on page ${pageNumber + 1}.`,
+        true,
+      );
+    } catch (error) {
+      console.error('Search All failed:', error);
+      ToastService.showToast('Search All operation failed', false);
+    }
+  };
+
+  const getActionDetails = (actionType: BulkActionType) => {
+    switch (actionType) {
+      case BulkActionType.ADD_ALL:
+        return {
+          icon: 'fa-solid fa-download',
+          label: 'Add All',
+          description: 'Add all available scenes on this page to Whisparr',
+          className: 'text-primary',
+        };
+      case BulkActionType.ADD_ALL_MISSING:
+        return {
+          icon: 'fa-solid fa-sync-alt',
+          label: 'Add All Missing',
+          description:
+            'Find and add all scenes missing from your Whisparr library',
+          className: 'text-success',
+        };
+      case BulkActionType.SEARCH_ALL:
+        return {
+          icon: 'fa-solid fa-search',
+          label: 'Search All',
+          description: 'Search all monitored scenes on this page in Whisparr',
+          className: 'text-warning',
+        };
+    }
+  };
+
+  return (
+    <div class="ms-3 mb-2">
+      <Dropdown show={isOpen()} onToggle={setIsOpen}>
+        <Dropdown.Toggle
+          variant="primary"
+          id="stasharr-actions-dropdown"
+          class="stasharr-button"
+          data-bs-toggle="tooltip"
+          data-bs-title="Bulk actions for scenes"
+        >
+          <FontAwesomeIcon icon="fa-solid fa-download" /> Stasharr Actions{' '}
+          <FontAwesomeIcon icon="fa-solid fa-chevron-down" />
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          <Dropdown.Header>Bulk Scene Actions</Dropdown.Header>
+
+          {[
+            BulkActionType.ADD_ALL,
+            BulkActionType.ADD_ALL_MISSING,
+            BulkActionType.SEARCH_ALL,
+          ].map((actionType) => {
+            const details = getActionDetails(actionType);
+            return (
+              <Dropdown.Item
+                onClick={() => handleAction(actionType)}
+                class={`${details.className} py-2`}
+              >
+                <div class="d-flex align-items-start">
+                  <div class="me-3 mt-1" style={{ width: '16px' }}>
+                    <FontAwesomeIcon icon={details.icon} />
+                  </div>
+                  <div>
+                    <div class="fw-semibold">{details.label}</div>
+                    <small class="text-muted">{details.description}</small>
+                  </div>
+                </div>
+              </Dropdown.Item>
+            );
+          })}
+
+          <Dropdown.Divider />
+          <Dropdown.ItemText class="text-muted small px-3">
+            Actions will show confirmation before executing
+          </Dropdown.ItemText>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  );
+};
+
+export default BulkActionDropdown;

--- a/src/components/BulkActionDropdown.tsx
+++ b/src/components/BulkActionDropdown.tsx
@@ -198,7 +198,7 @@ const BulkActionDropdown = () => {
       progressItems,
     );
 
-    // Set skipped information if there are scenes already in Whisparr
+    // Set skipped information (exclude-only scenes are already filtered elsewhere)
     if (alreadyInWhisparr > 0) {
       progressTracker.setSkippedInfo(alreadyInWhisparr, 'already in Whisparr');
     }
@@ -287,7 +287,7 @@ const BulkActionDropdown = () => {
     const stashIds: string[] = [];
     const progressItems: { id: string; name: string }[] = [];
 
-    let notSearchable = 0;
+    let alreadyInWhisparrHasFile = 0;
 
     // Count all scenes on page and categorize them
     allSceneCards.forEach((node) => {
@@ -298,11 +298,8 @@ const BulkActionDropdown = () => {
           ?.getAttribute(Stasharr.DataAttribute.SceneStatus);
         const sceneStatusNumber = parseInt(sceneStatusRaw || '-1', 10);
 
-        if (
-          sceneStatusNumber !== SceneStatus.EXISTS_AND_NO_FILE &&
-          sceneStatusNumber > -1
-        ) {
-          notSearchable++;
+        if (sceneStatusNumber === SceneStatus.EXISTS_AND_HAS_FILE) {
+          alreadyInWhisparrHasFile++;
         }
       }
     });
@@ -340,11 +337,11 @@ const BulkActionDropdown = () => {
       progressItems,
     );
 
-    // Set skipped information if there are scenes that can't be searched
-    if (notSearchable > 0) {
+    // Set skipped information for scenes that already have files
+    if (alreadyInWhisparrHasFile > 0) {
       progressTracker.setSkippedInfo(
-        notSearchable,
-        'not available for search (not in Whisparr or already have files)',
+        alreadyInWhisparrHasFile,
+        'already in Whisparr',
       );
     }
 

--- a/src/components/BulkActionDropdown.tsx
+++ b/src/components/BulkActionDropdown.tsx
@@ -1,5 +1,5 @@
 import { createSignal } from 'solid-js';
-import { Dropdown } from 'solid-bootstrap';
+import { Dropdown, Modal, Button } from 'solid-bootstrap';
 import { FontAwesomeIcon } from 'solid-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
@@ -7,6 +7,7 @@ import {
   faSearch,
   faDownload,
   faSyncAlt,
+  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons';
 import { useSettings } from '../contexts/useSettings';
 import SceneService from '../service/SceneService';
@@ -18,7 +19,13 @@ import { Stasharr } from '../enums/Stasharr';
 import { StashDB } from '../enums/StashDB';
 import { parseInt } from 'lodash';
 
-library.add(faChevronDown, faSearch, faDownload, faSyncAlt);
+library.add(
+  faChevronDown,
+  faSearch,
+  faDownload,
+  faSyncAlt,
+  faExclamationTriangle,
+);
 
 export enum BulkActionType {
   ADD_ALL = 'add_all',
@@ -29,13 +36,14 @@ export enum BulkActionType {
 const BulkActionDropdown = () => {
   const { store } = useSettings();
   const [isOpen, setIsOpen] = createSignal(false);
+  const [showConfirmModal, setShowConfirmModal] = createSignal(false);
 
   const handleAction = async (actionType: BulkActionType) => {
     setIsOpen(false);
 
     switch (actionType) {
       case BulkActionType.ADD_ALL_MISSING:
-        await handleAddAllMissing();
+        setShowConfirmModal(true);
         break;
       case BulkActionType.ADD_ALL:
         await handleAddAll();
@@ -47,12 +55,7 @@ const BulkActionDropdown = () => {
   };
 
   const handleAddAllMissing = async () => {
-    const confirmed = window.confirm(
-      'This will search StashDB and Whisparr to find ALL missing scenes from the current context (studio/performer/page). ' +
-        'This operation may take several minutes and will query both APIs extensively. Continue?',
-    );
-
-    if (!confirmed) return;
+    setShowConfirmModal(false);
 
     try {
       const results = await SceneService.addAllMissingScenes(store);
@@ -64,6 +67,10 @@ const BulkActionDropdown = () => {
       console.error('Add All Missing failed:', error);
       ToastService.showToast('Add All Missing operation failed', false);
     }
+  };
+
+  const handleConfirmCancel = () => {
+    setShowConfirmModal(false);
   };
 
   const handleAddAll = async () => {
@@ -173,53 +180,95 @@ const BulkActionDropdown = () => {
   };
 
   return (
-    <div class="ms-3 mb-2">
-      <Dropdown show={isOpen()} onToggle={setIsOpen}>
-        <Dropdown.Toggle
-          variant="primary"
-          id="stasharr-actions-dropdown"
-          class="stasharr-button"
-          data-bs-toggle="tooltip"
-          data-bs-title="Bulk actions for scenes"
-        >
-          <FontAwesomeIcon icon="fa-solid fa-download" /> Stasharr Actions{' '}
-          <FontAwesomeIcon icon="fa-solid fa-chevron-down" />
-        </Dropdown.Toggle>
+    <>
+      <div class="ms-3 mb-2">
+        <Dropdown show={isOpen()} onToggle={setIsOpen}>
+          <Dropdown.Toggle
+            variant="primary"
+            id="stasharr-actions-dropdown"
+            class="stasharr-button"
+            data-bs-toggle="tooltip"
+            data-bs-title="Bulk actions for scenes"
+          >
+            <FontAwesomeIcon icon="fa-solid fa-download" /> Stasharr Actions{' '}
+            <FontAwesomeIcon icon="fa-solid fa-chevron-down" />
+          </Dropdown.Toggle>
 
-        <Dropdown.Menu>
-          <Dropdown.Header>Bulk Scene Actions</Dropdown.Header>
+          <Dropdown.Menu>
+            <Dropdown.Header>Bulk Scene Actions</Dropdown.Header>
 
-          {[
-            BulkActionType.ADD_ALL,
-            BulkActionType.ADD_ALL_MISSING,
-            BulkActionType.SEARCH_ALL,
-          ].map((actionType) => {
-            const details = getActionDetails(actionType);
-            return (
-              <Dropdown.Item
-                onClick={() => handleAction(actionType)}
-                class={`${details.className} py-2`}
-              >
-                <div class="d-flex align-items-start">
-                  <div class="me-3 mt-1" style={{ width: '16px' }}>
-                    <FontAwesomeIcon icon={details.icon} />
+            {[
+              BulkActionType.ADD_ALL,
+              BulkActionType.ADD_ALL_MISSING,
+              BulkActionType.SEARCH_ALL,
+            ].map((actionType) => {
+              const details = getActionDetails(actionType);
+              return (
+                <Dropdown.Item
+                  onClick={() => handleAction(actionType)}
+                  class={`${details.className} py-2`}
+                >
+                  <div class="d-flex align-items-start">
+                    <div class="me-3 mt-1" style={{ width: '16px' }}>
+                      <FontAwesomeIcon icon={details.icon} />
+                    </div>
+                    <div>
+                      <div class="fw-semibold">{details.label}</div>
+                      <small class="text-muted">{details.description}</small>
+                    </div>
                   </div>
-                  <div>
-                    <div class="fw-semibold">{details.label}</div>
-                    <small class="text-muted">{details.description}</small>
-                  </div>
-                </div>
-              </Dropdown.Item>
-            );
-          })}
+                </Dropdown.Item>
+              );
+            })}
 
-          <Dropdown.Divider />
-          <Dropdown.ItemText class="text-muted small px-3">
-            Actions will show confirmation before executing
-          </Dropdown.ItemText>
-        </Dropdown.Menu>
-      </Dropdown>
-    </div>
+            <Dropdown.Divider />
+            <Dropdown.ItemText class="text-muted small px-3">
+              Actions will show confirmation before executing
+            </Dropdown.ItemText>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+
+      {/* Confirmation Modal for Add All Missing */}
+      <Modal show={showConfirmModal()} onHide={handleConfirmCancel} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <span class="me-2 text-warning">
+              <FontAwesomeIcon icon="fa-solid fa-sync-alt" />
+            </span>
+            Confirm Add All Missing
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div class="mb-3">
+            <p class="mb-2">
+              This will search StashDB and Whisparr to find{' '}
+              <strong>ALL missing scenes</strong> from the current context
+              (studio/performer/page).
+            </p>
+            <div class="alert alert-warning" role="alert">
+              <span class="me-2">
+                <FontAwesomeIcon icon="fa-solid fa-exclamation-triangle" />
+              </span>
+              <strong>Warning:</strong> This operation may take several minutes
+              and will query both APIs extensively.
+            </div>
+            <p class="mb-0 text-muted">Are you sure you want to continue?</p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleConfirmCancel}>
+            Cancel
+          </Button>
+          <Button variant="warning" onClick={handleAddAllMissing}>
+            <span class="me-2">
+              <FontAwesomeIcon icon="fa-solid fa-sync-alt" />
+            </span>
+            Continue
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/ProgressModal.tsx
+++ b/src/components/ProgressModal.tsx
@@ -1,0 +1,169 @@
+import { For, Show } from 'solid-js';
+import { Modal, Button, ProgressBar, Alert } from 'solid-bootstrap';
+import { FontAwesomeIcon } from 'solid-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import {
+  faClock,
+  faSpinner,
+  faCheckCircle,
+  faExclamationCircle,
+  faTasks,
+  faExclamationTriangle,
+} from '@fortawesome/free-solid-svg-icons';
+
+library.add(
+  faClock,
+  faSpinner,
+  faCheckCircle,
+  faExclamationCircle,
+  faTasks,
+  faExclamationTriangle,
+);
+
+export interface ProgressItem {
+  id: string;
+  name: string;
+  status: 'pending' | 'processing' | 'success' | 'error';
+  message?: string;
+}
+
+interface ProgressModalProps {
+  show: boolean;
+  title: string;
+  items: ProgressItem[];
+  onClose: () => void;
+  isComplete: boolean;
+  skippedCount?: number;
+  skippedReason?: string;
+}
+
+const ProgressModal = (props: ProgressModalProps) => {
+  const totalItems = () => props.items.length;
+  const completedItems = () =>
+    props.items.filter(
+      (item) => item.status === 'success' || item.status === 'error',
+    ).length;
+  const successCount = () =>
+    props.items.filter((item) => item.status === 'success').length;
+  const errorCount = () =>
+    props.items.filter((item) => item.status === 'error').length;
+  const progressPercentage = () =>
+    totalItems() > 0 ? (completedItems() / totalItems()) * 100 : 0;
+
+  const getStatusIcon = (status: ProgressItem['status']) => {
+    switch (status) {
+      case 'pending':
+        return { icon: 'fa-solid fa-clock', class: 'text-muted' };
+      case 'processing':
+        return { icon: 'fa-solid fa-spinner fa-spin', class: 'text-primary' };
+      case 'success':
+        return { icon: 'fa-solid fa-check-circle', class: 'text-success' };
+      case 'error':
+        return { icon: 'fa-solid fa-exclamation-circle', class: 'text-danger' };
+    }
+  };
+
+  return (
+    <Modal show={props.show} onHide={props.onClose} size="lg" centered>
+      <Modal.Header closeButton={props.isComplete}>
+        <Modal.Title>
+          <span class="me-2">
+            <FontAwesomeIcon icon="fa-solid fa-tasks" />
+          </span>
+          {props.title}
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        {/* Overall Progress */}
+        <div class="mb-4">
+          <div class="d-flex justify-content-between mb-2">
+            <span>
+              Progress: {completedItems()}/{totalItems()}
+            </span>
+            <span>{Math.round(progressPercentage())}%</span>
+          </div>
+          <ProgressBar
+            now={progressPercentage()}
+            variant={errorCount() > 0 ? 'warning' : 'success'}
+            style={{ height: '8px' }}
+          />
+        </div>
+
+        {/* Summary Stats */}
+        <div class="row mb-3">
+          <div class="col-4 text-center">
+            <div class="text-success fs-5">{successCount()}</div>
+            <small class="text-muted">Success</small>
+          </div>
+          <div class="col-4 text-center">
+            <div class="text-danger fs-5">{errorCount()}</div>
+            <small class="text-muted">Failed</small>
+          </div>
+          <div class="col-4 text-center">
+            <div class="text-muted fs-5">{totalItems() - completedItems()}</div>
+            <small class="text-muted">Remaining</small>
+          </div>
+        </div>
+
+        {/* Items List */}
+        <div style={{ 'max-height': '300px', overflow: 'auto' }}>
+          <For each={props.items}>
+            {(item) => {
+              const statusIcon = getStatusIcon(item.status);
+              return (
+                <div class="d-flex align-items-center mb-2 p-2 rounded border">
+                  <div class="me-3">
+                    <span class={statusIcon.class}>
+                      <FontAwesomeIcon icon={statusIcon.icon} />
+                    </span>
+                  </div>
+                  <div class="flex-grow-1">
+                    <div class="fw-medium">{item.name}</div>
+                    <Show when={item.message}>
+                      <small class="text-muted">{item.message}</small>
+                    </Show>
+                  </div>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+
+        {/* Completion Message */}
+        <Show when={props.isComplete}>
+          <Alert
+            variant={errorCount() > 0 ? 'warning' : 'success'}
+            class="mt-3"
+          >
+            <span class="me-2">
+              <FontAwesomeIcon
+                icon={
+                  errorCount() > 0
+                    ? 'fa-solid fa-exclamation-triangle'
+                    : 'fa-solid fa-check-circle'
+                }
+              />
+            </span>
+            Operation completed! {successCount()} succeeded, {errorCount()}{' '}
+            failed
+            {props.skippedCount && props.skippedCount > 0
+              ? `, ${props.skippedCount} skipped (${props.skippedReason})`
+              : ''}
+            .
+          </Alert>
+        </Show>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Show when={props.isComplete}>
+          <Button variant="primary" onClick={props.onClose}>
+            Close
+          </Button>
+        </Show>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default ProgressModal;

--- a/src/components/ProgressModal.tsx
+++ b/src/components/ProgressModal.tsx
@@ -106,6 +106,17 @@ const ProgressModal = (props: ProgressModalProps) => {
           </div>
         </div>
 
+        {/* Skipped Info (visible during progress and on completion) */}
+        <Show when={props.skippedCount && props.skippedCount > 0}>
+          <Alert variant="info" class="py-2 mb-3">
+            <span class="me-2">
+              <FontAwesomeIcon icon="fa-solid fa-exclamation-triangle" />
+            </span>
+            Skipped: {props.skippedCount}
+            {props.skippedReason ? ` (${props.skippedReason})` : ''}
+          </Alert>
+        </Show>
+
         {/* Items List */}
         <div style={{ 'max-height': '300px', overflow: 'auto' }}>
           <For each={props.items}>

--- a/src/components/SceneButton.tsx
+++ b/src/components/SceneButton.tsx
@@ -1,4 +1,11 @@
-import { createMemo, createResource, Match, Suspense, Switch } from 'solid-js';
+import {
+  createMemo,
+  createResource,
+  createEffect,
+  Match,
+  Suspense,
+  Switch,
+} from 'solid-js';
 import { Config } from '../models/Config';
 import { Stasharr } from '../enums/Stasharr';
 import { getButtonDetails, clickHandler } from '../util/button';
@@ -12,6 +19,7 @@ import {
   faSearch,
   faVideoSlash,
 } from '@fortawesome/free-solid-svg-icons';
+import { SceneButtonRefreshService } from '../service/SceneButtonRefreshService';
 
 library.add(faDownload, faCircleCheck, faSearch, faVideoSlash);
 
@@ -22,6 +30,13 @@ function SceneButton(props: {
 }) {
   const [whisparrSceneAndStatus, { refetch: refreshWhisparrSceneAndStatus }] =
     createResource(props, fetchWhisparrSceneAndStatus);
+
+  // Subscribe to global refresh events
+  const refreshSignal = SceneButtonRefreshService.getRefreshSignal();
+  createEffect(() => {
+    refreshSignal(); // Subscribe to the signal
+    refreshWhisparrSceneAndStatus(); // Refetch when signal changes
+  });
 
   const buttonDetails = createMemo(() =>
     getButtonDetails(whisparrSceneAndStatus(), props.header),

--- a/src/components/SceneList.tsx
+++ b/src/components/SceneList.tsx
@@ -23,6 +23,7 @@ const SceneList = (props: { config: Config }) => {
         isComplete={feedbackState().isComplete}
         skippedCount={feedbackState().skippedCount}
         skippedReason={feedbackState().skippedReason}
+        infoMessage={feedbackState().infoMessage}
         onClose={() => FeedbackService.closeProgressModal()}
       />
     </SettingsContext.Provider>

--- a/src/components/SceneList.tsx
+++ b/src/components/SceneList.tsx
@@ -1,15 +1,14 @@
 import { createStore } from 'solid-js/store';
 import { SettingsContext } from '../contexts/useSettings';
 import { Config } from '../models/Config';
-import BulkActionButton from './BulkActionButton';
+import BulkActionDropdown from './BulkActionDropdown';
 
 const SceneList = (props: { config: Config }) => {
   const [store, setStore] = createStore(props.config);
   return (
     <SettingsContext.Provider value={{ store, setStore }}>
       <div class="d-flex justify-content-end">
-        <BulkActionButton actionType="add" />
-        <BulkActionButton actionType="search" />
+        <BulkActionDropdown />
       </div>
     </SettingsContext.Provider>
   );

--- a/src/components/SceneList.tsx
+++ b/src/components/SceneList.tsx
@@ -2,14 +2,29 @@ import { createStore } from 'solid-js/store';
 import { SettingsContext } from '../contexts/useSettings';
 import { Config } from '../models/Config';
 import BulkActionDropdown from './BulkActionDropdown';
+import ProgressModal from './ProgressModal';
+import FeedbackService from '../service/FeedbackService';
 
 const SceneList = (props: { config: Config }) => {
   const [store, setStore] = createStore(props.config);
+
+  const feedbackState = FeedbackService.getFeedbackState();
+
   return (
     <SettingsContext.Provider value={{ store, setStore }}>
       <div class="d-flex justify-content-end">
         <BulkActionDropdown />
       </div>
+
+      <ProgressModal
+        show={feedbackState().showProgressModal}
+        title={feedbackState().modalTitle}
+        items={feedbackState().progressItems}
+        isComplete={feedbackState().isComplete}
+        skippedCount={feedbackState().skippedCount}
+        skippedReason={feedbackState().skippedReason}
+        onClose={() => FeedbackService.closeProgressModal()}
+      />
     </SettingsContext.Provider>
   );
 };

--- a/src/components/scene/card/CardButton.tsx
+++ b/src/components/scene/card/CardButton.tsx
@@ -2,6 +2,7 @@ import { FontAwesomeIcon } from 'solid-fontawesome';
 import {
   createResource,
   createMemo,
+  createEffect,
   Suspense,
   Switch,
   Match,
@@ -14,10 +15,18 @@ import LoadingButton from '../../LoadingButton';
 import { SceneStatus } from '../../../enums/SceneStatus';
 import StashSceneService from '../../../service/stash/StashSceneService';
 import ExternalLink from '../../common/ExternalLink';
+import { SceneButtonRefreshService } from '../../../service/SceneButtonRefreshService';
 
 const CardButton = (props: { config: Config; stashId: string }) => {
   const [whisparrSceneAndStatus, { refetch: refreshWhisparrSceneAndStatus }] =
     createResource(props, fetchWhisparrSceneAndStatus);
+
+  // Subscribe to global refresh events
+  const refreshSignal = SceneButtonRefreshService.getRefreshSignal();
+  createEffect(() => {
+    refreshSignal(); // Subscribe to the signal
+    refreshWhisparrSceneAndStatus(); // Refetch when signal changes
+  });
 
   const buttonDetails = createMemo(() =>
     getButtonDetails(whisparrSceneAndStatus(), false),

--- a/src/controller/NavbarController.ts
+++ b/src/controller/NavbarController.ts
@@ -25,9 +25,27 @@ export class NavbarController extends BaseController {
   }
 
   initialize(): void {
+    console.log('🎯 NavbarController: initialize() called');
+
+    // Check if Stasharr nav link already exists
+    const existingStasharrLink = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('.nav-link'),
+    ).find((link) => link.textContent?.trim() === 'Stasharr');
+
+    if (existingStasharrLink) {
+      console.log(
+        '🎯 NavbarController: Stasharr nav link already exists, skipping render',
+      );
+      return;
+    }
+
     const navbar = document.querySelector(StashDB.DOMSelector.Navbar);
+    console.log('🎯 NavbarController: navbar found:', !!navbar);
+
     if (navbar) {
+      console.log('🎯 NavbarController: Rendering SettingsModal to navbar');
       render(() => SettingsModal({ config: this._config }), navbar);
+      console.log('🎯 NavbarController: SettingsModal render complete');
     }
   }
 }

--- a/src/controller/PerformerController.ts
+++ b/src/controller/PerformerController.ts
@@ -17,6 +17,11 @@ export class PerformerController extends BaseController {
     return false;
   }
   initialize(): void {
+    // Only initialize on performer pages
+    if (!window.location.pathname.includes('/performers/')) {
+      return;
+    }
+
     const performerStashId = extractStashIdFromPath();
     if (this._config.whisparrApiKey == '' || performerStashId == null) return;
 

--- a/src/controller/ScenesListController.ts
+++ b/src/controller/ScenesListController.ts
@@ -1,5 +1,4 @@
 import { Config } from '../models/Config';
-import { Stasharr } from '../enums/Stasharr';
 import { render } from 'solid-js/web';
 import { BaseController } from './BaseController';
 import { SceneListMutationHandler } from '../mutation-handlers/SceneListMutationHandler';
@@ -15,28 +14,89 @@ export class ScenesListController extends BaseController {
   }
 
   initialize() {
+    console.log('🎯 ScenesListController: initialize() called');
+    console.log('🔍 Current URL:', window.location.href);
+    console.log('🔍 Whisparr API key present:', !!this._config.whisparrApiKey);
+
     if (this._config.whisparrApiKey) {
       const sceneListCommandRow =
         document.querySelector<HTMLDivElement>('.scenes-list');
-      const addAllAvailableButton = document.querySelector(
-        Stasharr.DOMSelector.AddAllAvailable,
-      );
 
-      const searchAllAvailableButton = document.querySelector(
-        Stasharr.DOMSelector.SearchAllExisting,
+      console.log(
+        '🎯 ScenesListController: sceneListCommandRow found:',
+        !!sceneListCommandRow,
       );
-
-      const placeholder = document.createElement('div');
 
       if (sceneListCommandRow) {
-        if (!addAllAvailableButton && !searchAllAvailableButton) {
+        console.log('🎯 ScenesListController: .scenes-list element details:');
+        console.log(
+          '  - innerHTML length:',
+          sceneListCommandRow.innerHTML.length,
+        );
+        console.log('  - children count:', sceneListCommandRow.children.length);
+        console.log(
+          '  - first child tag:',
+          sceneListCommandRow.firstChild?.nodeName,
+        );
+
+        // Check for existing Stasharr elements
+        const existingStasharrActions = document.querySelector(
+          '#stasharr-actions-dropdown',
+        );
+        const existingStasharrButtons =
+          sceneListCommandRow.querySelectorAll('.stasharr-button');
+
+        console.log(
+          '🎯 ScenesListController: existing actions dropdown:',
+          !!existingStasharrActions,
+        );
+        console.log(
+          '🎯 ScenesListController: existing stasharr buttons count:',
+          existingStasharrButtons.length,
+        );
+
+        // Only add if no Stasharr actions exist
+        if (!existingStasharrActions && existingStasharrButtons.length === 0) {
+          console.log(
+            '🎯 ScenesListController: Adding new SceneList component',
+          );
+          const placeholder = document.createElement('div');
+          placeholder.id = 'stasharr-scene-list-placeholder';
           sceneListCommandRow.insertBefore(
             placeholder,
             sceneListCommandRow.firstChild,
           );
+          console.log(
+            '🎯 ScenesListController: Placeholder added, rendering SceneList...',
+          );
           render(() => SceneList({ config: this._config }), placeholder);
+          console.log('🎯 ScenesListController: SceneList render complete');
+        } else {
+          console.log(
+            '🎯 ScenesListController: Skipped - Stasharr elements already exist',
+          );
         }
+      } else {
+        console.log('🎯 ScenesListController: No .scenes-list container found');
+        // Let's see what scene-related elements are available
+        const sceneElements = document.querySelectorAll('[class*="scene"]');
+        console.log(
+          '🎯 ScenesListController: Found scene-related elements:',
+          sceneElements.length,
+        );
+        sceneElements.forEach((el, i) => {
+          if (i < 5) {
+            // Only log first 5 to avoid spam
+            console.log(
+              `  - ${el.tagName}.${Array.from(el.classList).join('.')}`,
+            );
+          }
+        });
       }
+    } else {
+      console.log(
+        '🎯 ScenesListController: Skipped - No Whisparr API key configured',
+      );
     }
   }
 }

--- a/src/controller/StudioController.ts
+++ b/src/controller/StudioController.ts
@@ -22,6 +22,11 @@ export class StudioController extends BaseController {
   }
 
   initialize() {
+    // Only initialize on studio pages
+    if (!window.location.pathname.includes('/studios/')) {
+      return;
+    }
+
     const studioStashId = extractStashIdFromPath();
     if (this._config.whisparrApiKey == '' || studioStashId == null) return;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,8 @@
-import { CardController } from './controller/CardController';
-import { PerformerController } from './controller/PerformerController';
-import { NavbarController } from './controller/NavbarController';
-import { ScenesListController } from './controller/ScenesListController';
-import { StudioController } from './controller/StudioController';
 import { TooltipManager } from './service/TooltipManager';
+import { ControllerManager } from './service/ControllerManager';
 
 import './styles/main.scss';
 import { Config } from './models/Config';
-import { DetailsController } from './controller/scene/DetailsController';
 
 (async function () {
   // Wait for DOM to be ready
@@ -21,10 +16,132 @@ import { DetailsController } from './controller/scene/DetailsController';
   TooltipManager.initialize();
 
   const config = new Config().load();
-  new NavbarController(config);
-  new PerformerController(config);
-  new StudioController(config);
-  new ScenesListController(config);
-  new CardController(config);
-  new DetailsController(config);
+
+  // Initial setup
+  ControllerManager.initializeControllers(config);
+
+  // Enhanced navigation detection for React-based SPAs
+  let lastUrl = window.location.href;
+  let reinitializationTimer: number;
+
+  const checkForNavigation = () => {
+    const currentUrl = window.location.href;
+    if (currentUrl !== lastUrl) {
+      console.log(`🚀 NAVIGATION DETECTED: ${lastUrl} → ${currentUrl}`);
+      lastUrl = currentUrl;
+
+      // Clear any pending reinitializations
+      if (reinitializationTimer) {
+        console.log('⏰ Clearing previous reinitialization timer');
+        clearTimeout(reinitializationTimer);
+      }
+
+      // Wait longer for React to finish rendering
+      console.log('⏳ Setting reinitialization timer for 300ms...');
+      reinitializationTimer = window.setTimeout(() => {
+        console.log(
+          '🔄 Timer triggered - calling ControllerManager.reinitialize',
+        );
+        ControllerManager.reinitialize(config);
+      }, 300);
+    }
+  };
+
+  // Poll for URL changes (catches React Router navigation)
+  setInterval(checkForNavigation, 500);
+
+  // Traditional navigation events (still needed for direct browser actions)
+  window.addEventListener('popstate', (event) => {
+    console.log(
+      '🔙 POPSTATE EVENT detected (back/forward button):',
+      event.state,
+    );
+    checkForNavigation();
+  });
+
+  // Override history methods for programmatic navigation
+  const originalPushState = history.pushState;
+  const originalReplaceState = history.replaceState;
+
+  history.pushState = function (...args) {
+    console.log('📌 PUSHSTATE detected:', args[2]); // URL is the 3rd argument
+    originalPushState.apply(history, args);
+    setTimeout(checkForNavigation, 50);
+  };
+
+  history.replaceState = function (...args) {
+    console.log('🔄 REPLACESTATE detected:', args[2]); // URL is the 3rd argument
+    originalReplaceState.apply(history, args);
+    setTimeout(checkForNavigation, 50);
+  };
+
+  // Additional React-specific detection
+  // Listen for DOM changes that might indicate React navigation
+  const reactNavigationObserver = new MutationObserver((mutations) => {
+    let significantChange = false;
+    let detectedChanges: string[] = [];
+
+    mutations.forEach((mutation) => {
+      // Check if major page structures changed (indicates navigation)
+      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof Element) {
+            // Look for indicators of new page content
+            if (node.classList?.contains('row')) {
+              significantChange = true;
+              detectedChanges.push('row added');
+            }
+            if (node.classList?.contains('main')) {
+              significantChange = true;
+              detectedChanges.push('main added');
+            }
+            if (node.classList?.contains('content')) {
+              significantChange = true;
+              detectedChanges.push('content added');
+            }
+            if (node.querySelector?.('.scenes-list')) {
+              significantChange = true;
+              detectedChanges.push('scenes-list found');
+            }
+          }
+        });
+      }
+    });
+
+    if (significantChange) {
+      console.log(
+        '🔍 DOM MUTATION detected - possible React navigation:',
+        detectedChanges.join(', '),
+      );
+      setTimeout(checkForNavigation, 100);
+    }
+  });
+
+  // Observe the main content area for React-driven changes
+  const mainContent =
+    document.querySelector('#root') ||
+    document.querySelector('main') ||
+    document.body;
+
+  console.log(
+    '🔍 Setting up DOM observer on:',
+    mainContent?.tagName + (mainContent?.id ? '#' + mainContent.id : ''),
+  );
+
+  if (mainContent) {
+    reactNavigationObserver.observe(mainContent, {
+      childList: true,
+      subtree: true,
+    });
+    console.log('✅ DOM observer is active');
+  } else {
+    console.log('❌ No suitable container found for DOM observer');
+  }
+
+  // Add initial state logging
+  console.log('🎯 Initial URL:', window.location.href);
+  console.log(
+    '🎯 Looking for .scenes-list on load:',
+    !!document.querySelector('.scenes-list'),
+  );
 })();

--- a/src/interfaces/Controller.ts
+++ b/src/interfaces/Controller.ts
@@ -1,4 +1,5 @@
 export interface Controller {
+  observer: MutationObserver;
   initialize(): void;
   shouldReinit(node: HTMLElement): boolean;
 }

--- a/src/service/ControllerManager.ts
+++ b/src/service/ControllerManager.ts
@@ -91,6 +91,23 @@ export class ControllerManager {
     ];
 
     let totalRemoved = 0;
+
+    // Also clean up duplicate Stasharr nav links
+    const stasharrNavLinks = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('.nav-link'),
+    ).filter((link) => link.textContent?.trim() === 'Stasharr');
+
+    if (stasharrNavLinks.length > 1) {
+      console.log(
+        `ControllerManager: Found ${stasharrNavLinks.length} duplicate Stasharr nav links, removing extras`,
+      );
+      // Keep the first one, remove the rest
+      stasharrNavLinks.slice(1).forEach((link) => {
+        console.log('ControllerManager: Removing duplicate Stasharr nav link');
+        link.remove();
+        totalRemoved++;
+      });
+    }
     stasharrSelectors.forEach((selector) => {
       const elements = document.querySelectorAll(selector);
       elements.forEach((element) => {

--- a/src/service/ControllerManager.ts
+++ b/src/service/ControllerManager.ts
@@ -1,0 +1,167 @@
+import { Config } from '../models/Config';
+import { CardController } from '../controller/CardController';
+import { PerformerController } from '../controller/PerformerController';
+import { NavbarController } from '../controller/NavbarController';
+import { ScenesListController } from '../controller/ScenesListController';
+import { StudioController } from '../controller/StudioController';
+import { DetailsController } from '../controller/scene/DetailsController';
+import { Controller } from '../interfaces/Controller';
+
+/**
+ * Manages controller lifecycle and prevents duplicate initialization
+ */
+export class ControllerManager {
+  private static controllers: Controller[] = [];
+
+  /**
+   * Initialize all controllers, disposing of previous instances first
+   */
+  static initializeControllers(config: Config): void {
+    // Dispose of existing controllers to prevent duplicate observers
+    this.disposeControllers();
+
+    console.log('ControllerManager: Initializing all controllers...');
+
+    // Create new controller instances
+    this.controllers = [
+      new NavbarController(config),
+      new PerformerController(config),
+      new StudioController(config),
+      new ScenesListController(config),
+      new CardController(config),
+      new DetailsController(config),
+    ];
+
+    console.log(
+      `ControllerManager: Created ${this.controllers.length} controllers`,
+    );
+
+    // Initialize each controller with debugging
+    this.controllers.forEach((controller, index) => {
+      console.log(
+        `ControllerManager: Initializing controller ${index} (${controller.constructor.name})`,
+      );
+      try {
+        controller.initialize();
+        console.log(
+          `ControllerManager: ✅ Controller ${index} (${controller.constructor.name}) initialized successfully`,
+        );
+      } catch (error) {
+        console.error(
+          `ControllerManager: ❌ Controller ${index} (${controller.constructor.name}) failed:`,
+          error,
+        );
+      }
+    });
+
+    console.log(
+      `ControllerManager: Completed initialization of ${this.controllers.length} controllers`,
+    );
+  }
+
+  /**
+   * Dispose of all current controllers to clean up observers
+   */
+  private static disposeControllers(): void {
+    this.controllers.forEach((controller, index) => {
+      if (controller.observer) {
+        console.log(`ControllerManager: Disposing controller ${index}`);
+        controller.observer.disconnect();
+      }
+    });
+    this.controllers = [];
+
+    // Clean up stale Stasharr DOM elements that might be disconnected from SolidJS
+    this.cleanupStaleElements();
+  }
+
+  /**
+   * Remove stale Stasharr elements that are no longer connected to SolidJS components
+   */
+  private static cleanupStaleElements(): void {
+    console.log('ControllerManager: Starting comprehensive cleanup...');
+
+    // More aggressive cleanup for React-based SPAs
+    const stasharrSelectors = [
+      '[id*="stasharr"]', // Any element with 'stasharr' in ID
+      '[class*="stasharr"]', // Any element with 'stasharr' in class
+      '#stasharr-actions-dropdown', // Specific dropdown ID
+      '.dropdown-menu', // Bootstrap dropdowns (may be orphaned)
+      '[data-bs-toggle="tooltip"]', // Tooltip elements
+    ];
+
+    let totalRemoved = 0;
+    stasharrSelectors.forEach((selector) => {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach((element) => {
+        // Be more aggressive - remove any element that looks Stasharr-related
+        const isStasharrElement =
+          element.id?.includes('stasharr') ||
+          Array.from(element.classList || []).some((cls) =>
+            cls.includes('stasharr'),
+          ) ||
+          element.closest('.scenes-list') ||
+          // Check if it's a Bootstrap dropdown that might be orphaned from Stasharr
+          (element.classList?.contains('dropdown-menu') &&
+            element.previousElementSibling?.id?.includes('stasharr'));
+
+        if (isStasharrElement) {
+          console.log(
+            `ControllerManager: Removing stale element: ${element.tagName}#${element.id || 'no-id'}.${Array.from(element.classList || []).join('.')}`,
+          );
+          element.remove();
+          totalRemoved++;
+        }
+      });
+    });
+
+    // Clean up any orphaned SolidJS elements within scenes-list
+    // Use specific known SolidJS attribute names instead of wildcard
+    const solidJSSelectors = [
+      '[data-solid-render-effect]',
+      '[data-solid-context]',
+      '[data-solid-component]',
+      '[data-solid-portal]',
+    ];
+
+    solidJSSelectors.forEach((selector) => {
+      try {
+        const elements = document.querySelectorAll(selector);
+        elements.forEach((element) => {
+          if (element.closest('.scenes-list')) {
+            console.log(
+              `ControllerManager: Removing orphaned SolidJS element: ${selector}`,
+            );
+            element.remove();
+            totalRemoved++;
+          }
+        });
+      } catch {
+        // Silently skip any invalid selectors
+        console.warn(
+          `ControllerManager: Skipped invalid selector: ${selector}`,
+        );
+      }
+    });
+
+    console.log(
+      `ControllerManager: Cleanup complete - removed ${totalRemoved} elements`,
+    );
+  }
+
+  /**
+   * Force re-initialization (useful for navigation events)
+   */
+  static reinitialize(config: Config): void {
+    console.log('🔄 ControllerManager: Forced re-initialization requested');
+    console.log(
+      '🔍 Current .scenes-list present:',
+      !!document.querySelector('.scenes-list'),
+    );
+    console.log(
+      '🔍 Existing stasharr buttons:',
+      document.querySelectorAll('[id*="stasharr"], [class*="stasharr"]').length,
+    );
+    this.initializeControllers(config);
+  }
+}

--- a/src/service/ExclusionListService.ts
+++ b/src/service/ExclusionListService.ts
@@ -7,17 +7,22 @@ import ServiceBase from './ServiceBase';
 import ToastService from './ToastService';
 
 export default class ExclusionListService extends ServiceBase {
-  static async getExclusionsMap(config: Config): Promise<ExclusionsMap> {
+  static async getExclusionsMap(
+    config: Config,
+    suppressToasts?: boolean,
+  ): Promise<ExclusionsMap> {
     const endpoint = 'exclusions';
     let map: ExclusionsMap = new Map();
     let response;
     try {
       response = await ServiceBase.request(config, endpoint);
     } catch (e) {
-      ToastService.showToast(
-        'Error occurred while looking up Exclusions List',
-        false,
-      );
+      if (!suppressToasts) {
+        ToastService.showToast(
+          'Error occurred while looking up Exclusions List',
+          false,
+        );
+      }
       console.error('Error in getExclusionsMap:', e);
       return map;
     }

--- a/src/service/FeedbackService.ts
+++ b/src/service/FeedbackService.ts
@@ -9,6 +9,7 @@ export interface FeedbackState {
   isComplete: boolean;
   skippedCount?: number;
   skippedReason?: string;
+  infoMessage?: string;
 }
 
 // Global feedback state
@@ -45,6 +46,7 @@ export default class FeedbackService {
       modalTitle: title,
       progressItems,
       isComplete: false,
+      infoMessage: undefined,
     });
 
     return {
@@ -54,6 +56,7 @@ export default class FeedbackService {
       removeItem: this.removeProgressItem.bind(this),
       updateItemName: this.updateProgressItemName.bind(this),
       updateItemNames: this.updateProgressItemNames.bind(this),
+      setInfo: this.setInfoMessage.bind(this),
       setSkippedInfo: this.setSkippedInfo.bind(this),
     };
   }
@@ -111,6 +114,14 @@ export default class FeedbackService {
     setFeedbackState((prev) => ({
       ...prev,
       progressItems: prev.progressItems.filter((item) => item.id !== itemId),
+    }));
+  }
+
+  // Set an informational message for empty-state or general info
+  static setInfoMessage(message?: string) {
+    setFeedbackState((prev) => ({
+      ...prev,
+      infoMessage: message,
     }));
   }
 

--- a/src/service/FeedbackService.ts
+++ b/src/service/FeedbackService.ts
@@ -1,0 +1,286 @@
+import { createSignal } from 'solid-js';
+import { ProgressItem } from '../components/ProgressModal';
+import ToastService from './ToastService';
+
+export interface FeedbackState {
+  showProgressModal: boolean;
+  modalTitle: string;
+  progressItems: ProgressItem[];
+  isComplete: boolean;
+  skippedCount?: number;
+  skippedReason?: string;
+}
+
+// Global feedback state
+const [feedbackState, setFeedbackState] = createSignal<FeedbackState>({
+  showProgressModal: false,
+  modalTitle: '',
+  progressItems: [],
+  isComplete: false,
+});
+
+export default class FeedbackService {
+  private static buttonStates = new Map<
+    string,
+    { originalHTML: string; isActive: boolean }
+  >();
+
+  // Get the current feedback state (reactive)
+  static getFeedbackState() {
+    return feedbackState;
+  }
+
+  // Start a bulk operation with progress tracking
+  static startBulkOperation(
+    title: string,
+    items: { id: string; name: string }[],
+  ) {
+    const progressItems: ProgressItem[] = items.map((item) => ({
+      ...item,
+      status: 'pending' as const,
+    }));
+
+    setFeedbackState({
+      showProgressModal: true,
+      modalTitle: title,
+      progressItems,
+      isComplete: false,
+    });
+
+    return {
+      updateItem: this.updateProgressItem.bind(this),
+      complete: this.completeBulkOperation.bind(this),
+      addItems: this.addProgressItems.bind(this),
+      removeItem: this.removeProgressItem.bind(this),
+      updateItemName: this.updateProgressItemName.bind(this),
+      updateItemNames: this.updateProgressItemNames.bind(this),
+      setSkippedInfo: this.setSkippedInfo.bind(this),
+    };
+  }
+
+  // Update a specific item's status
+  static updateProgressItem(
+    id: string,
+    status: ProgressItem['status'],
+    message?: string,
+  ) {
+    setFeedbackState((prev) => ({
+      ...prev,
+      progressItems: prev.progressItems.map((item) =>
+        item.id === id ? { ...item, status, message } : item,
+      ),
+    }));
+  }
+
+  // Add new items to an existing bulk operation
+  static addProgressItems(items: { id: string; name: string }[]) {
+    const newProgressItems: ProgressItem[] = items.map((item) => ({
+      ...item,
+      status: 'pending' as const,
+    }));
+
+    setFeedbackState((prev) => ({
+      ...prev,
+      progressItems: [...prev.progressItems, ...newProgressItems],
+    }));
+  }
+
+  // Update the display name of a specific progress item
+  static updateProgressItemName(id: string, name: string) {
+    setFeedbackState((prev) => ({
+      ...prev,
+      progressItems: prev.progressItems.map((item) =>
+        item.id === id ? { ...item, name } : item,
+      ),
+    }));
+  }
+
+  // Bulk update display names for multiple items
+  static updateProgressItemNames(items: { id: string; name: string }[]) {
+    const nameMap = new Map(items.map((i) => [i.id, i.name] as const));
+    setFeedbackState((prev) => ({
+      ...prev,
+      progressItems: prev.progressItems.map((item) =>
+        nameMap.has(item.id) ? { ...item, name: nameMap.get(item.id)! } : item,
+      ),
+    }));
+  }
+
+  // Remove a specific progress item
+  static removeProgressItem(itemId: string) {
+    setFeedbackState((prev) => ({
+      ...prev,
+      progressItems: prev.progressItems.filter((item) => item.id !== itemId),
+    }));
+  }
+
+  // Set information about skipped items
+  static setSkippedInfo(count: number, reason: string) {
+    setFeedbackState((prev) => ({
+      ...prev,
+      skippedCount: count,
+      skippedReason: reason,
+    }));
+  }
+
+  // Mark the bulk operation as complete
+  static completeBulkOperation() {
+    setFeedbackState((prev) => ({
+      ...prev,
+      isComplete: true,
+    }));
+  }
+
+  // Close the progress modal
+  static closeProgressModal() {
+    setFeedbackState((prev) => ({
+      ...prev,
+      showProgressModal: false,
+    }));
+  }
+
+  // Start an operation on a button
+  static startButtonOperation(buttonId: string, operationText: string) {
+    const button = document.querySelector(`#${buttonId}`) as HTMLElement;
+    if (!button) return;
+
+    // Store original state if not already stored
+    if (!this.buttonStates.has(buttonId)) {
+      this.buttonStates.set(buttonId, {
+        originalHTML: button.innerHTML,
+        isActive: false,
+      });
+    }
+
+    const state = this.buttonStates.get(buttonId)!;
+    state.isActive = true;
+    button.textContent = operationText;
+  }
+
+  // Complete an operation on a button
+  static completeButtonOperation(
+    buttonId: string,
+    completionText?: string,
+    duration = 3000,
+  ) {
+    const button = document.querySelector(`#${buttonId}`) as HTMLElement;
+    const state = this.buttonStates.get(buttonId);
+    if (!button || !state || !state.isActive) return;
+
+    if (completionText) {
+      // Show completion text briefly, then restore
+      button.textContent = completionText;
+      setTimeout(() => {
+        if (state.isActive) {
+          button.innerHTML = state.originalHTML;
+          state.isActive = false;
+        }
+      }, duration);
+    } else {
+      // Restore immediately
+      button.innerHTML = state.originalHTML;
+      state.isActive = false;
+    }
+  }
+
+  // Legacy method for backward compatibility - now maps to state-driven approach
+  static updateButtonStatus(
+    buttonId: string,
+    newText: string,
+    duration: number = 3000,
+  ) {
+    // If this is a completion message (contains numbers/results), treat as completion
+    if (
+      /\d/.test(newText) &&
+      (newText.includes('Added') ||
+        newText.includes('Searched') ||
+        newText.includes('Failed'))
+    ) {
+      this.completeButtonOperation(buttonId, newText, duration);
+    } else {
+      // Otherwise treat as starting an operation
+      this.startButtonOperation(buttonId, newText);
+    }
+  }
+
+  // Show persistent error (keeps toasts for errors)
+  static showError(message: string) {
+    ToastService.showPersistentToast(message, false);
+  }
+
+  // Show quick success feedback (auto-dismiss)
+  static showSuccess(message: string) {
+    ToastService.showToast(message, true);
+  }
+
+  // Update scene card status (in-context feedback)
+  static updateSceneCard(
+    sceneId: string,
+    status: 'processing' | 'success' | 'error',
+  ) {
+    const sceneCard = document.querySelector(
+      `[data-scene-id="${sceneId}"]`,
+    ) as HTMLElement;
+    if (!sceneCard) return;
+
+    // Remove existing status classes
+    sceneCard.classList.remove(
+      'scene-processing',
+      'scene-success',
+      'scene-error',
+    );
+
+    // Add new status class
+    sceneCard.classList.add(`scene-${status}`);
+
+    // Add visual indicator
+    let indicator = sceneCard.querySelector(
+      '.scene-status-indicator',
+    ) as HTMLElement;
+    if (!indicator) {
+      indicator = document.createElement('div');
+      indicator.className =
+        'scene-status-indicator position-absolute top-0 end-0 m-2';
+      sceneCard.style.position = 'relative';
+      sceneCard.appendChild(indicator);
+    }
+
+    const icons = {
+      processing: '<i class="fa-solid fa-spinner fa-spin text-primary"></i>',
+      success: '<i class="fa-solid fa-check-circle text-success"></i>',
+      error: '<i class="fa-solid fa-exclamation-circle text-danger"></i>',
+    };
+
+    indicator.innerHTML = icons[status];
+
+    // Auto-remove success indicators after 5 seconds
+    if (status === 'success') {
+      setTimeout(() => {
+        if (indicator && indicator.parentNode) {
+          indicator.remove();
+          sceneCard.classList.remove('scene-success');
+        }
+      }, 5000);
+    }
+  }
+
+  // Browser notification for important operations (requires permission)
+  static async showNotification(title: string, message: string) {
+    if ('Notification' in window) {
+      if (Notification.permission === 'granted') {
+        new Notification(title, {
+          body: message,
+          icon: '/favicon.ico',
+        });
+      } else if (Notification.permission !== 'denied') {
+        const permission = await Notification.requestPermission();
+        if (permission === 'granted') {
+          new Notification(title, {
+            body: message,
+            icon: '/favicon.ico',
+          });
+        }
+      }
+    }
+  }
+}

--- a/src/service/SceneButtonRefreshService.ts
+++ b/src/service/SceneButtonRefreshService.ts
@@ -1,0 +1,37 @@
+import { createSignal, Accessor } from 'solid-js';
+
+/**
+ * Service for managing global scene button refresh events
+ */
+export class SceneButtonRefreshService {
+  private static refreshSignal = createSignal(0);
+  private static refreshCount = this.refreshSignal[0];
+  private static setRefreshCount = this.refreshSignal[1];
+
+  /**
+   * Get the refresh signal accessor for components to subscribe to
+   */
+  static getRefreshSignal(): Accessor<number> {
+    return this.refreshCount;
+  }
+
+  /**
+   * Trigger a global refresh of all scene buttons
+   * This increments the signal value, causing all subscribers to re-run
+   */
+  static triggerRefresh(): void {
+    console.log('SceneButtonRefreshService: Triggering global button refresh');
+    this.setRefreshCount((count) => count + 1);
+  }
+
+  /**
+   * Trigger refresh for specific scene IDs (for targeted updates)
+   * For now this does a global refresh, but could be enhanced for targeted updates
+   */
+  static triggerRefreshForScenes(sceneIds: string[]): void {
+    console.log(
+      `SceneButtonRefreshService: Triggering refresh for ${sceneIds.length} scenes`,
+    );
+    this.triggerRefresh();
+  }
+}

--- a/src/service/SceneComparisonService.ts
+++ b/src/service/SceneComparisonService.ts
@@ -1,0 +1,232 @@
+import { Config } from '../models/Config';
+import { Whisparr } from '../types/whisparr';
+import { StashDBScene } from './StashDBService';
+import StashDBService from './StashDBService';
+import WhisparrService from './WhisparrService';
+import ExclusionListService from './ExclusionListService';
+import ToastService from './ToastService';
+
+export interface MissingSceneInfo {
+  stashdbScene: StashDBScene;
+  reason: 'not_in_whisparr' | 'excluded';
+}
+
+export interface SceneComparisonResult {
+  stashdbScenes: StashDBScene[];
+  whisparrScenes: Whisparr.WhisparrScene[];
+  missingScenes: MissingSceneInfo[];
+  existingStashIds: Set<string>;
+  excludedStashIds: Set<string>;
+  totalStashDBScenes: number;
+  totalWhisparrScenes: number;
+  totalMissing: number;
+}
+
+export interface ComparisonFilters {
+  studios?: string[];
+  performers?: string[];
+  tags?: string[];
+  excludeExisting?: boolean;
+  excludeExcluded?: boolean;
+}
+
+export default class SceneComparisonService {
+  /**
+   * Perform comprehensive comparison between StashDB and Whisparr
+   */
+  static async compareScenes(
+    config: Config,
+    filters: ComparisonFilters = {},
+  ): Promise<SceneComparisonResult> {
+    try {
+      console.log('Starting comprehensive scene comparison...');
+      ToastService.showToast('Analyzing scene libraries...', true);
+
+      // Fetch data from both platforms in parallel
+      const [stashdbScenes, whisparrScenes, exclusionMap] = await Promise.all([
+        this.fetchStashDBScenes(filters),
+        WhisparrService.getAllScenes(config),
+        ExclusionListService.getExclusionsMap(config),
+      ]);
+
+      console.log(
+        `Fetched ${stashdbScenes.length} StashDB scenes and ${whisparrScenes.length} Whisparr scenes`,
+      );
+
+      // Create lookup maps for efficient comparison
+      const whisparrStashIdMap =
+        WhisparrService.createStashIdToSceneMap(whisparrScenes);
+      const existingStashIds = new Set(whisparrStashIdMap.keys());
+      const excludedStashIds = new Set(exclusionMap.keys());
+
+      // Find missing scenes
+      const missingScenes: MissingSceneInfo[] = [];
+
+      for (const stashdbScene of stashdbScenes) {
+        const isExcluded = excludedStashIds.has(stashdbScene.id);
+        const existsInWhisparr = existingStashIds.has(stashdbScene.id);
+
+        if (!existsInWhisparr) {
+          if (filters.excludeExcluded && isExcluded) {
+            continue; // Skip excluded scenes if requested
+          }
+
+          missingScenes.push({
+            stashdbScene,
+            reason: isExcluded ? 'excluded' : 'not_in_whisparr',
+          });
+        }
+      }
+
+      const result: SceneComparisonResult = {
+        stashdbScenes,
+        whisparrScenes,
+        missingScenes,
+        existingStashIds,
+        excludedStashIds,
+        totalStashDBScenes: stashdbScenes.length,
+        totalWhisparrScenes: whisparrScenes.length,
+        totalMissing: missingScenes.length,
+      };
+
+      console.log(
+        `Comparison complete: ${result.totalMissing} missing scenes found`,
+      );
+      ToastService.showToast(
+        `Found ${result.totalMissing} missing scenes out of ${result.totalStashDBScenes} StashDB scenes`,
+        true,
+      );
+
+      return result;
+    } catch (error) {
+      console.error('Scene comparison failed:', error);
+      ToastService.showToast('Failed to compare scene libraries', false);
+      throw error;
+    }
+  }
+
+  /**
+   * Find scenes missing from specific context (current page, studio, performer)
+   */
+  static async findMissingScenes(
+    config: Config,
+    filters: ComparisonFilters = {},
+  ): Promise<StashDBScene[]> {
+    const comparison = await this.compareScenes(config, {
+      ...filters,
+      excludeExcluded: true, // Don't include excluded scenes in missing list
+    });
+
+    return comparison.missingScenes
+      .filter((missing) => missing.reason === 'not_in_whisparr')
+      .map((missing) => missing.stashdbScene);
+  }
+
+  /**
+   * Get scene IDs that are safe to add (not excluded, not existing)
+   */
+  static async getSafeToAddSceneIds(
+    config: Config,
+    stashdbSceneIds: string[],
+  ): Promise<string[]> {
+    const [whisparrScenes, exclusionMap] = await Promise.all([
+      WhisparrService.getAllScenes(config),
+      ExclusionListService.getExclusionsMap(config),
+    ]);
+
+    console.log(whisparrScenes);
+
+    const existingStashIds = new Set(
+      whisparrScenes.map((scene) => scene.stashId),
+    );
+    const excludedStashIds = new Set(exclusionMap.keys());
+
+    return stashdbSceneIds.filter(
+      (sceneId) =>
+        !existingStashIds.has(sceneId) && !excludedStashIds.has(sceneId),
+    );
+  }
+
+  /**
+   * Fetch StashDB scenes based on filters
+   */
+  private static async fetchStashDBScenes(
+    filters: ComparisonFilters,
+  ): Promise<StashDBScene[]> {
+    if (filters.studios && filters.studios.length > 0) {
+      return await StashDBService.getAllScenesFromStudios(filters.studios);
+    }
+
+    if (filters.performers && filters.performers.length > 0) {
+      return await StashDBService.getAllPerformerScenes(filters.performers);
+    }
+
+    // Default to comprehensive fetch with optional text/tag filters
+    return await StashDBService.getAllScenes({
+      tags: filters.tags,
+    });
+  }
+
+  /**
+   * Extract unique studio IDs from current page URL
+   */
+  static extractCurrentPageStudioIds(): string[] {
+    const studioIds = new Set<string>();
+
+    // Extract from studio page if we're on a studio page
+    const studioMatch = window.location.pathname.match(
+      /\/studios\/([a-f0-9-]+)/,
+    );
+    if (studioMatch) {
+      studioIds.add(studioMatch[1]);
+    }
+
+    return Array.from(studioIds);
+  }
+
+  /**
+   * Extract unique performer IDs from current page URL
+   */
+  static extractCurrentPagePerformerIds(): string[] {
+    const performerIds = new Set<string>();
+
+    // Extract from performer page if we're on a performer page
+    const performerMatch = window.location.pathname.match(
+      /\/performers\/([a-f0-9-]+)/,
+    );
+    if (performerMatch) {
+      performerIds.add(performerMatch[1]);
+    }
+
+    return Array.from(performerIds);
+  }
+
+  /**
+   * Analyze current page context and suggest optimal comparison strategy
+   */
+  static analyzeCurrentPageContext(): ComparisonFilters {
+    const studioIds = this.extractCurrentPageStudioIds();
+    const performerIds = this.extractCurrentPagePerformerIds();
+
+    const filters: ComparisonFilters = {
+      excludeExisting: true,
+      excludeExcluded: true,
+    };
+
+    if (studioIds.length > 0) {
+      filters.studios = studioIds;
+      console.log(
+        `Context: Studio-based comparison with ${studioIds.length} studios`,
+      );
+    } else if (performerIds.length > 0) {
+      filters.performers = performerIds;
+      console.log(
+        `Context: Performer-based comparison with ${performerIds.length} performers`,
+      );
+    } else {
+      console.log('Context: General comparison (all scenes)');
+    }
+
+    return filters;
+  }
+}

--- a/src/service/SceneService.ts
+++ b/src/service/SceneService.ts
@@ -378,11 +378,11 @@ export default class SceneService extends ServiceBase {
 
       // Update the search progress and add only the scenes that will actually be processed
       if (progressTracker) {
-        const skippedCount = missingScenes.length - safeScenes.length;
+        const skippedTotal = missingScenes.length - safeScenes.length;
         let message = `Found ${missingScenes.length} scenes, ${safeScenes.length} will be added`;
 
-        if (skippedCount > 0) {
-          message += `, ${skippedCount} skipped (already in Whisparr)`;
+        if (skippedTotal > 0) {
+          message += `, ${skippedTotal} skipped (already in Whisparr)`;
         }
 
         progressTracker.updateItem('search', 'success', message);
@@ -395,8 +395,8 @@ export default class SceneService extends ServiceBase {
         progressTracker.addItems(sceneProgressItems);
 
         // Set information about skipped scenes
-        if (skippedCount > 0) {
-          progressTracker.setSkippedInfo(skippedCount, 'already in Whisparr');
+        if (skippedTotal > 0) {
+          progressTracker.setSkippedInfo(skippedTotal, 'already in Whisparr');
         }
 
         // Remove the search item now that we have the actual scenes

--- a/src/service/StashDBService.ts
+++ b/src/service/StashDBService.ts
@@ -1,0 +1,331 @@
+import ServiceBase from './ServiceBase';
+import ToastService from './ToastService';
+
+export interface StashDBScene {
+  id: string;
+  title: string;
+  release_date?: string;
+  studio?: {
+    id: string;
+    name: string;
+  };
+  performers?: Array<{
+    id: string;
+    name: string;
+    as?: string;
+  }>;
+  fingerprints?: Array<{
+    hash: string;
+    algorithm: string;
+    duration: number;
+  }>;
+}
+
+export interface StashDBQueryInput {
+  text?: string;
+  studios?: string[];
+  performers?: string[];
+  tags?: string[];
+  page?: number;
+  per_page?: number;
+  sort?: 'TITLE' | 'DATE' | 'TRENDING';
+  direction?: 'ASC' | 'DESC';
+}
+
+export interface StashDBScenesResponse {
+  queryScenes: {
+    scenes: StashDBScene[];
+    count: number;
+  };
+}
+
+export default class StashDBService extends ServiceBase {
+  private static readonly STASHDB_ENDPOINT = 'https://stashdb.org/graphql';
+  private static readonly ITEMS_PER_PAGE = 100;
+
+  /**
+   * Get the stashbox cookie value for authentication
+   */
+  private static getStashboxCookie(): string | null {
+    const cookies = document.cookie.split(';');
+    for (const cookie of cookies) {
+      const [name, value] = cookie.trim().split('=');
+      if (name === 'stashbox') {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Execute a GraphQL query against StashDB
+   */
+  private static async executeQuery(
+    query: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    try {
+      const stashboxCookie = this.getStashboxCookie();
+      if (!stashboxCookie) {
+        throw new Error(
+          'StashDB authentication cookie not found. Please log into StashDB first.',
+        );
+      }
+
+      const response = await fetch(this.STASHDB_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `stashbox=${stashboxCookie}`,
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`StashDB API error: ${response.statusText}`);
+      }
+
+      const result = await response.json();
+
+      if (result.errors) {
+        console.error('StashDB GraphQL errors:', result.errors);
+        throw new Error(
+          `GraphQL errors: ${result.errors.map((e: { message: string }) => e.message).join(', ')}`,
+        );
+      }
+
+      return result.data;
+    } catch (error) {
+      console.error('StashDB query failed:', error);
+      ToastService.showToast('Failed to query StashDB', false);
+      throw error;
+    }
+  }
+
+  /**
+   * Search scenes on StashDB with pagination support
+   */
+  static async searchScenes(
+    queryInput: StashDBQueryInput,
+  ): Promise<StashDBScenesResponse> {
+    const query = `
+      query QueryScenes($input: SceneQueryInput!) {
+        queryScenes(input: $input) {
+          count
+          scenes {
+            id
+            title
+            release_date
+            studio {
+              id
+              name
+            }
+            performers {
+              performer {
+                id
+                name
+              }
+              as
+            }
+            fingerprints {
+              hash
+              algorithm
+              duration
+            }
+          }
+        }
+      }
+    `;
+
+    const input: Record<string, unknown> = {
+      page: queryInput.page || 1,
+      per_page: Math.min(
+        queryInput.per_page || this.ITEMS_PER_PAGE,
+        this.ITEMS_PER_PAGE,
+      ),
+      sort: queryInput.sort || 'DATE',
+      direction: queryInput.direction || 'DESC',
+    };
+
+    // Add text search if provided
+    if (queryInput.text) {
+      input.text = queryInput.text;
+    }
+
+    // Add studios filter with correct MultiIDCriterionInput format
+    if (queryInput.studios && queryInput.studios.length > 0) {
+      input.studios = {
+        value: queryInput.studios,
+        modifier: 'EQUALS',
+      };
+    }
+
+    // Add performers filter with correct MultiIDCriterionInput format
+    if (queryInput.performers && queryInput.performers.length > 0) {
+      input.performers = {
+        value: queryInput.performers,
+        modifier: 'INCLUDES_ALL',
+      };
+    }
+
+    // Add tags filter with correct MultiIDCriterionInput format
+    if (queryInput.tags && queryInput.tags.length > 0) {
+      input.tags = {
+        value: queryInput.tags,
+        modifier: 'INCLUDES_ALL',
+      };
+    }
+
+    console.log(input);
+
+    return (await this.executeQuery(query, { input })) as StashDBScenesResponse;
+  }
+
+  /**
+   * Get all scenes from multiple studios
+   */
+  static async getAllScenesFromStudios(
+    studioIds: string[],
+  ): Promise<StashDBScene[]> {
+    const allScenes: StashDBScene[] = [];
+    let page = 1;
+    let hasMore = true;
+
+    console.log(`Fetching StashDB scenes from ${studioIds.length} studios...`);
+
+    while (hasMore) {
+      console.log(`Fetching StashDB studio scenes page ${page}...`);
+
+      try {
+        const response = await this.searchScenes({
+          studios: studioIds,
+          page,
+          per_page: this.ITEMS_PER_PAGE,
+          sort: 'DATE',
+          direction: 'DESC',
+        });
+
+        const scenes = response.queryScenes.scenes;
+        allScenes.push(...scenes);
+
+        hasMore = scenes.length === this.ITEMS_PER_PAGE;
+        page++;
+
+        // Add small delay to avoid rate limiting
+        if (hasMore) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+      } catch (error) {
+        console.error(`Failed to fetch scenes from studios:`, error);
+        break;
+      }
+    }
+
+    console.log(
+      `Fetched ${allScenes.length} scenes from ${studioIds.length} studios`,
+    );
+    return allScenes;
+  }
+
+  /**
+   * Search scenes by performer(s) with pagination
+   */
+  static async getAllPerformerScenes(
+    performerIds: string[],
+  ): Promise<StashDBScene[]> {
+    const allScenes: StashDBScene[] = [];
+    let page = 1;
+    let hasMore = true;
+
+    while (hasMore) {
+      console.log(`Fetching StashDB performer scenes page ${page}...`);
+
+      const response = await this.searchScenes({
+        performers: performerIds,
+        page,
+        per_page: this.ITEMS_PER_PAGE,
+        sort: 'DATE',
+        direction: 'DESC',
+      });
+
+      const scenes = response.queryScenes.scenes;
+      allScenes.push(...scenes);
+
+      hasMore = scenes.length === this.ITEMS_PER_PAGE;
+      page++;
+
+      // Add small delay to avoid rate limiting
+      if (hasMore) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    }
+
+    console.log(`Fetched ${allScenes.length} scenes for performers`);
+    return allScenes;
+  }
+
+  /**
+   * Get all scenes with comprehensive pagination
+   */
+  static async getAllScenes(
+    filters: Omit<StashDBQueryInput, 'page' | 'per_page'> = {},
+  ): Promise<StashDBScene[]> {
+    const allScenes: StashDBScene[] = [];
+    let page = 1;
+    let hasMore = true;
+    let totalFetched = 0;
+
+    console.log('Starting comprehensive StashDB scene fetch...');
+
+    while (hasMore) {
+      console.log(`Fetching StashDB scenes page ${page}...`);
+
+      try {
+        const response = await this.searchScenes({
+          ...filters,
+          page,
+          per_page: this.ITEMS_PER_PAGE,
+        });
+
+        const scenes = response.queryScenes.scenes;
+        allScenes.push(...scenes);
+        totalFetched += scenes.length;
+
+        hasMore = scenes.length === this.ITEMS_PER_PAGE;
+        page++;
+
+        // Add delay to avoid rate limiting
+        if (hasMore) {
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+
+        // Safety check to avoid infinite loops
+        if (totalFetched > 50000) {
+          console.warn('StashDB fetch limit reached, stopping pagination');
+          ToastService.showToast(
+            'StashDB query limit reached - partial results returned',
+            true,
+          );
+          break;
+        }
+      } catch (error) {
+        console.error(`Failed to fetch StashDB page ${page}:`, error);
+        break;
+      }
+    }
+
+    console.log(`Total StashDB scenes fetched: ${totalFetched}`);
+    return allScenes;
+  }
+
+  /**
+   * Extract StashDB scene IDs from scene objects
+   */
+  static extractSceneIds(scenes: StashDBScene[]): string[] {
+    return scenes.map((scene) => scene.id);
+  }
+}

--- a/src/service/ToastService.ts
+++ b/src/service/ToastService.ts
@@ -2,6 +2,21 @@ import { Toast } from 'bootstrap';
 
 export default class ToastService {
   public static showToast(message: string, isSuccess: boolean = true): void {
+    this.createToast(message, isSuccess, false);
+  }
+
+  public static showPersistentToast(
+    message: string,
+    isSuccess: boolean = true,
+  ): void {
+    this.createToast(message, isSuccess, true);
+  }
+
+  private static createToast(
+    message: string,
+    isSuccess: boolean,
+    persistent: boolean,
+  ): void {
     const toastContainer = document.querySelector('.ToastContainer');
     if (toastContainer) {
       toastContainer.classList.add('toast-container');
@@ -15,6 +30,11 @@ export default class ToastService {
       customToast.role = 'alert';
       customToast.ariaLive = 'assertive';
       customToast.ariaAtomic = 'true';
+
+      // Set data-bs-autohide to false for persistent toasts
+      if (persistent) {
+        customToast.setAttribute('data-bs-autohide', 'false');
+      }
 
       const dflex = document.createElement('div');
       dflex.classList.add('d-flex');
@@ -42,7 +62,10 @@ export default class ToastService {
       customToast.addEventListener('hidden.bs.toast', () => {
         customToast.remove();
       });
-      const toast = new Toast(customToast);
+
+      const toast = new Toast(customToast, {
+        autohide: !persistent,
+      });
       toast.show();
     } else {
       console.log('ToastContainer not found.');

--- a/src/service/WhisparrService.ts
+++ b/src/service/WhisparrService.ts
@@ -100,4 +100,72 @@ export default class WhisparrService extends ServiceBase {
     }
     return response.response as Whisparr.Tag[];
   }
+
+  /**
+   * Fetches all scenes from Whisparr with pagination support
+   */
+  static async getAllScenes(config: Config): Promise<Whisparr.WhisparrScene[]> {
+    const allScenes: Whisparr.WhisparrScene[] = [];
+    let page = 1;
+    const pageSize = 100;
+    let hasMore = true;
+
+    console.log('Starting Whisparr scene inventory fetch...');
+
+    while (hasMore) {
+      console.log(`Fetching Whisparr scenes page ${page}...`);
+
+      try {
+        const endpoint = `movie?page=${page}&pageSize=${pageSize}`;
+        const response = await ServiceBase.request(
+          config,
+          endpoint,
+          'GET',
+          undefined,
+        );
+        const scenes = response.response as Whisparr.WhisparrScene[];
+
+        if (scenes && scenes.length > 0) {
+          allScenes.push(...scenes);
+          hasMore = scenes.length === pageSize;
+          page++;
+
+          // Add small delay to avoid overwhelming the API
+          if (hasMore) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+        } else {
+          hasMore = false;
+        }
+      } catch (error) {
+        console.error(`Failed to fetch Whisparr scenes page ${page}:`, error);
+        ToastService.showToast(
+          `Error fetching scenes from Whisparr: ${error}`,
+          false,
+        );
+        break;
+      }
+    }
+
+    console.log(`Total Whisparr scenes fetched: ${allScenes.length}`);
+    return allScenes;
+  }
+
+  /**
+   * Create a map of Stash ID to Whisparr scene for quick lookups
+   */
+  static createStashIdToSceneMap(
+    scenes: Whisparr.WhisparrScene[],
+  ): Map<string, Whisparr.WhisparrScene> {
+    const map = new Map<string, Whisparr.WhisparrScene>();
+
+    scenes.forEach((scene) => {
+      if (scene.foreignId && scene.foreignId.startsWith('stash:')) {
+        const stashId = scene.foreignId.replace('stash:', '');
+        map.set(stashId, scene);
+      }
+    });
+
+    return map;
+  }
 }

--- a/src/service/WhisparrService.ts
+++ b/src/service/WhisparrService.ts
@@ -104,7 +104,10 @@ export default class WhisparrService extends ServiceBase {
   /**
    * Fetches all scenes from Whisparr with pagination support
    */
-  static async getAllScenes(config: Config): Promise<Whisparr.WhisparrScene[]> {
+  static async getAllScenes(
+    config: Config,
+    options?: { suppressToasts?: boolean },
+  ): Promise<Whisparr.WhisparrScene[]> {
     const allScenes: Whisparr.WhisparrScene[] = [];
     let page = 1;
     const pageSize = 100;
@@ -139,10 +142,12 @@ export default class WhisparrService extends ServiceBase {
         }
       } catch (error) {
         console.error(`Failed to fetch Whisparr scenes page ${page}:`, error);
-        ToastService.showToast(
-          `Error fetching scenes from Whisparr: ${error}`,
-          false,
-        );
+        if (!options?.suppressToasts) {
+          ToastService.showToast(
+            `Error fetching scenes from Whisparr: ${error}`,
+            false,
+          );
+        }
         break;
       }
     }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,3 +4,31 @@
 @use 'components/modal';
 @use 'components/whisparr';
 @use 'components/stash';
+
+// Scene card status feedback styles
+.scene-processing {
+  border: 2px solid var(--bs-primary) !important;
+  box-shadow: 0 0 10px rgba(13, 110, 253, 0.3);
+}
+
+.scene-success {
+  border: 2px solid var(--bs-success) !important;
+  box-shadow: 0 0 10px rgba(25, 135, 84, 0.3);
+}
+
+.scene-error {
+  border: 2px solid var(--bs-danger) !important;
+  box-shadow: 0 0 10px rgba(220, 53, 69, 0.3);
+}
+
+.scene-status-indicator {
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
This PR enhances the Stasharr bulk actions UX and reliability.

What’s included
- Titles: use StashDB find-by-ID for accurate scene titles in progress items
- Modal feedback: replace toasts during bulk work with progress modal updates
- Skipped info: show counts and reason (already in Whisparr) consistently
- Empty-state: show clear info when there’s nothing to add/search (no false success)
- Consistency: use scene titles for Add on Page and Search on Page like Add Missing
- Toast suppression: propagate suppressToasts across services to avoid noisy popups

Implementation highlights
- StashDBService: add getSceneById; refactor getSceneTitlesByIds to use it
- FeedbackService/ProgressModal: support infoMessage and in-place item name updates
- BulkActionDropdown: update names in-place; show skipped; empty-state via setInfo
- SceneService / SceneComparisonService / WhisparrService / ExclusionListService: plumb suppressToasts in bulk flows

Why
- Ensure users see scene titles (not hashes) and accurate, centralized progress
- Avoid misleading success when no scenes are actionable
- Provide clear skipped counts and consistent language

QA notes
- Verify bulk actions on pages with:
  - No actionable scenes: modal shows info, Progress hidden, 0/0
  - Mixed scenes: titles populate; skipped shows “already in Whisparr”
  - Errors: item messages display; modal completes with summary
